### PR TITLE
Add support for different oidc-agent accounts

### DIFF
--- a/common/oidc-agent.robot
+++ b/common/oidc-agent.robot
@@ -1,11 +1,12 @@
 *** Variables ***
 
 ${oidc-agent.scope.default}   -s storage.read:/ -s storage.modify:/ -s openid
+${oidc-agent.account}  wlcg
 ${bearer.env}   BEARER_TOKEN
 
 *** Keywords ***
 
-Get token   [Arguments]   ${issuer}=wlcg  ${scope}=${oidc-agent.scope.default}  ${opts}=${EMPTY}
+Get token   [Arguments]   ${issuer}=${oidc-agent.account}  ${scope}=${oidc-agent.scope.default}  ${opts}=${EMPTY}
     ${rc}  ${out}   Execute and Check Success   oidc-token ${scope} ${opts} ${issuer} 
     Set Environment Variable   ${bearer.env}   ${out}
     [Return]   ${out}


### PR DESCRIPTION
Motivation:

Not everyone has the WLCG OP configured within oidc-agent with the
(short) account name 'wlcg'.

Modification:

Define a variable through which the oidc-agent account name may be
configured, using a robot command-line like:

    -v oidc-agent.account:WLCG

or, with the current runner script:

    ROBOT_ARGS="-v oidc-agent.account:WLCG" ./run-testsuite.sh

Result:

The conformancy tests can now use tokens from a user-defined oidc-agent
account.