### PR TITLE
Configure Requests to trust IGTF trust bundle by default

### DIFF
--- a/common/curl.robot
+++ b/common/curl.robot
@@ -4,9 +4,7 @@ Resource   common/utils.robot
 Resource   common/oidc-agent.robot
 
 *** Variables ***
-
-${x509.trustdir}  /etc/grid-security/certificates
-${curl.opts.default}  -s -L -i -f --show-error --capath ${x509.trustdir}
+${curl.opts.default}  -s -L -i -f --show-error --capath ${x509.trustanchors}
 
 *** Keywords ***
 

--- a/test/__init__.robot
+++ b/test/__init__.robot
@@ -15,6 +15,7 @@ Suite Setup   Default Suite Setup
 
 *** Keywords ***
 Default Suite Setup
+     Set Environment Variable  REQUESTS_CA_BUNDLE  ${x509.trustanchors}
      ${SUITE_UUID}   Generate UUID 
      Set Global Variable   ${SUITE_UUID}   ${suite_uuid}
      ${token}   Get token

--- a/test/variables.yaml
+++ b/test/variables.yaml
@@ -2,6 +2,8 @@ oauth:
   token:
     issuer: https://wlcg.cloud.cnaf.infn.it/
 
+x509.trustanchors: /etc/grid-security/certificates
+
 oidc-agent:
   provider-alias: wlcg
 


### PR DESCRIPTION
Motivation:

Grid services typically authenticate themselves using an X.509
credential where the certificate has been issued by an IGTF-approved CA.

Such CAs are typically not trusted by non-grid clients and so such grid
services are not trusted by default.

Therefore, out-of-the-box the Requests HTTP client Python library will
fail when connecting the grid sites

Motification:

Move the trust bundle configuration from curl.robot into the generic
variables.yaml configuraiton.  This allows configuration to be shared
between tests and suite initialisation.

Update suite initialisation to set the REQUESTS_CA_BUNDLE environment
variable to specify the trust anchors that the requests library should
use.

Result:

The Requests HTTP client library now trusts IGTF CAs.