### PR TITLE
Drop dependency on HttpLibrary robot-framework library

### DIFF
--- a/common/http.robot
+++ b/common/http.robot
@@ -4,8 +4,6 @@ Resource   common/utils.robot
 Resource   common/oidc-agent.robot
 Resource   common/endpoint.robot
 
-Library   HttpLibrary
-
 *** Keywords ***
 
 SE Context


### PR DESCRIPTION
Motivation:

HttpLibrary is not being used here.  It is also an abandoned project and
does not support Python 3.

Modification:

Remove 'Library' line.

Result:

No more errors when running test suite with python3