### PR TITLE
Add RAL-LCG2 test instance to tests

### DIFF
--- a/test/variables.yaml
+++ b/test/variables.yaml
@@ -62,4 +62,9 @@ endpoints:
     endpoint: https://dpmhead-trunk.cern.ch
     paths:
       wlcg: /dpm/cern.ch/home/wlcg
-      
+  ral-test-xrootd:
+    desc: Test gateway for Echo
+    type: XRootD
+    endpoint: https://ceph-gw8.gridpp.rl.ac.uk:1094
+    paths:
+      wlcg: /dteam:wlcg


### PR DESCRIPTION
Include ral-test-xrootd as a test instance for RAL-LCG2 Echo