### PR TITLE
Create parent directory if needed

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -42,7 +42,7 @@ else
   export BEARER_TOKEN=$(oidc-token wlcg)
   echo "Uploading report to ${REPORTS_URL}"
 
-  gfal-mkdir ${REPORTS_URL}/${now}
+  gfal-mkdir -p ${REPORTS_URL}/${now}
   gfal-copy -r ${reports_dir} ${REPORTS_URL}/${now}
 fi
 


### PR DESCRIPTION
It prevents to fail in case of parent directory does not exist.

This should fix the CI error when uploading test reports.  

Tested locally.