### PR TITLE
Added lock resource option

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     ansiColor('xterm')
     disableConcurrentBuilds()
     timestamps()
-    lock resource: 'ts-run-locked-resource'
+    lock resource: 'wlcg-jwt-compliance-lock'
   }
 
   triggers { cron('0 10 * * *') }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
     ansiColor('xterm')
     disableConcurrentBuilds()
     timestamps()
+    lock resource: 'ts-run-locked-resource'
   }
 
   triggers { cron('0 10 * * *') }


### PR DESCRIPTION
Added lock resource option in the Jenkins pipeline in order to prevent concurrent runs of the same container.

It is an issue when the CI runs on the same node and we cannot disable concurrent jobs by configuration (*i.e.* PR from forks).