### PR TITLE
Cnsd 228

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
     OIDC_AGENT_SECRET = credentials('wlcg_jwt_oidc_agent_secret')
     REPORTS_DIR_BASE = '/tmp/reports'
     SKIP_REPORT_UPLOAD = 'y'
-    MAIL_RECIPIENTS = 'federica.agostini89@gmail.com'
+    MAIL_RECIPIENTS = 'wlcg-doma-tpc@cern.ch'
   }
 
   stages {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -53,8 +53,8 @@ pipeline {
       steps {
         script {
           emailext to: "${env.MAIL_RECIPIENTS}",
-          subject: "[Jenkins] ${env.JOB_NAME} report ${env.BUILD_TIMESTAMP}",
-          attachmentsPattern: '**/reports/reports/latest/*',
+          subject: "WLCG JWT compliance test report ${env.BUILD_TIMESTAMP}",
+          attachmentsPattern: 'reports/reports/latest/*.html',
           body: "More info at ${env.BUILD_URL}artifact/reports/reports/latest/"
         }
       }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -13,15 +13,11 @@ pipeline {
 
   triggers { cron('0 10 * * *') }
 
-  parameters {
-    string(defaultValue: 'federica.agostini89@gmail.com', description: 'Job report\'s mail recipients', name: 'MAIL_RECIPIENTS')
-  }
-
   environment {
     OIDC_AGENT_SECRET = credentials('wlcg_jwt_oidc_agent_secret')
     REPORTS_DIR_BASE = '/tmp/reports'
     SKIP_REPORT_UPLOAD = 'y'
-    MAIL_RECIPIENTS = "${params.MAIL_RECIPIENTS}"
+    MAIL_RECIPIENTS = 'federica.agostini89@gmail.com'
   }
 
   stages {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -49,14 +49,17 @@ pipeline {
 
     stage('send email'){
       when {
-        triggeredBy "TimerTrigger"    
+        allOf {
+          triggeredBy "TimerTrigger"
+          branch "master"
+        }
       }
       steps {
         script {
           emailext to: "${env.MAIL_RECIPIENTS}",
           subject: "[Jenkins] ${env.JOB_NAME} report ${env.BUILD_TIMESTAMP}",
-          mimeType: 'text/html',
-          body: '${FILE,path="reports/reports/latest/joint-report.html"}'
+          attachmentsPattern: '**/reports/reports/latest/*',
+          body: "More info at ${env.BUILD_URL}artifact/reports/reports/latest/"
         }
       }
     }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     lock resource: 'wlcg-jwt-compliance-lock'
   }
 
-  triggers { cron('H/10 * * * *') }
+  triggers { cron('0 10 * * *') }
 
   parameters {
     string(defaultValue: 'federica.agostini89@gmail.com', description: 'Job report\'s mail recipients', name: 'MAIL_RECIPIENTS')

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
       when {
         allOf {
           triggeredBy "TimerTrigger"
-          branch "CNSD-228"
+          branch "master"
         }
       }
       steps {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -53,9 +53,10 @@ pipeline {
       }
       steps {
         script {
-          emailext body: "${currentBuild.currentResult}: Job ${env.JOB_NAME} build ${env.BUILD_NUMBER}\nMore info at: ${env.BUILD_URL}",
+          emailext to: "${env.MAIL_RECIPIENTS}",
           subject: "[Jenkins] ${env.JOB_NAME} report ${env.BUILD_TIMESTAMP}",
-          to: "${MAIL_RECIPIENTS}"
+          mimeType: 'text/html',
+          body: '${FILE,path="reports/reports/latest/joint-report.html"}'
         }
       }
     }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -55,7 +55,6 @@ pipeline {
           emailext to: "${env.MAIL_RECIPIENTS}",
           replyTo: "noreply@cnaf.infn.it",
           subject: "WLCG JWT compliance test report - #${env.BUILD_NUMBER} ${env.BUILD_TIMESTAMP}",
-          attachmentsPattern: "reports/reports/latest/joint-*.html",
           body: "More info at ${env.BUILD_URL}artifact/reports/reports/latest/joint-report.html"
         }
       }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
       steps {
         script {
           emailext body: "${currentBuild.currentResult}: Job ${env.JOB_NAME} build ${env.BUILD_NUMBER}\nMore info at: ${env.BUILD_URL}",
-          subject: "Jenkins Build ${currentBuild.currentResult}: Job ${env.JOB_NAME}",
+          subject: "[Jenkins] ${env.JOB_NAME} report ${env.BUILD_TIMESTAMP}",
           to: "${MAIL_RECIPIENTS}"
         }
       }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -53,9 +53,10 @@ pipeline {
       steps {
         script {
           emailext to: "${env.MAIL_RECIPIENTS}",
-          subject: "WLCG JWT compliance test report ${env.BUILD_TIMESTAMP}",
-          attachmentsPattern: 'reports/reports/latest/*.html',
-          body: "More info at ${env.BUILD_URL}artifact/reports/reports/latest/"
+          replyTo: "noreply@cnaf.infn.it",
+          subject: "WLCG JWT compliance test report - #${env.BUILD_NUMBER} ${env.BUILD_TIMESTAMP}",
+          attachmentsPattern: "reports/reports/latest/joint-*.html",
+          body: "More info at ${env.BUILD_URL}artifact/reports/reports/latest/joint-report.html"
         }
       }
     }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     lock resource: 'wlcg-jwt-compliance-lock'
   }
 
-  triggers { cron('0 10 * * *') }
+  triggers { cron('H/10 * * * *') }
 
   parameters {
     string(defaultValue: 'federica.agostini89@gmail.com', description: 'Job report\'s mail recipients', name: 'MAIL_RECIPIENTS')
@@ -51,7 +51,7 @@ pipeline {
       when {
         allOf {
           triggeredBy "TimerTrigger"
-          branch "master"
+          branch "CNSD-228"
         }
       }
       steps {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -13,10 +13,15 @@ pipeline {
 
   triggers { cron('0 10 * * *') }
 
+  parameters {
+    string(defaultValue: 'federica.agostini89@gmail.com', description: 'Job report\'s mail recipients', name: 'MAIL_RECIPIENTS')
+  }
+
   environment {
     OIDC_AGENT_SECRET = credentials('wlcg_jwt_oidc_agent_secret')
     REPORTS_DIR_BASE = '/tmp/reports'
     SKIP_REPORT_UPLOAD = 'y'
+    MAIL_RECIPIENTS = "${params.MAIL_RECIPIENTS}"
   }
 
   stages {
@@ -39,6 +44,19 @@ pipeline {
       steps {
         sh "docker cp wlcg-jwt-tests_ts_1:/tmp/reports ."
         archive 'reports/**'
+      }
+    }
+
+    stage('send email'){
+      when {
+        triggeredBy "TimerTrigger"    
+      }
+      steps {
+        script {
+          emailext body: "${currentBuild.currentResult}: Job ${env.JOB_NAME} build ${env.BUILD_NUMBER}\nMore info at: ${env.BUILD_URL}",
+          subject: "Jenkins Build ${currentBuild.currentResult}: Job ${env.JOB_NAME}",
+          to: "${MAIL_RECIPIENTS}"
+        }
       }
     }
   }

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -14,7 +14,7 @@ oidc-add --pw-cmd='echo $OIDC_AGENT_SECRET' wlcg
 
 endpoints=$(cat test/variables.yaml | shyaml keys endpoints | grep -v se-storm-example)
 
-reports_dir=${REPORTS_DIR_BASE}/reports/${now}
+reports_dir=${REPORTS_DIR_BASE}/reports/latest
 
 mkdir -p ${reports_dir}
 


### PR DESCRIPTION
Proposal for email notification of wlcg token-based test suite report.

The email is sent once a day (conditioned on the Jenkins job's trigger) from the `master` branch job. It is not sent if the job fails.

The email content is the following:
* subject: "WLCG JWT compliance test report <job_time>"
* attachment: robot report and log
* content: "More info at <job_artifact_url>"
* to: my account for now, but intended to be sent to doma-tpc mailing list

The email layout looks like 
![email_jenkins_wlcg-jwt-compliance-test](https://user-images.githubusercontent.com/13579100/143218437-2a29f4dd-3af8-49c9-806e-59db5ed85da4.png)

