### PR TITLE
Fix docker image build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /reports/*
+__pycache__

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ENV TEST_USER_UID $TEST_USER_UID
 RUN   yum clean all && \
       yum install -y hostname epel-release && \
       yum -y update && \
-      yum -y install which wget tar gcc openssl-devel sudo file make which && \
+      yum -y install which wget tar gcc openssl-devel sudo file make which python36 && \
       echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
       adduser --uid ${TEST_USER_UID} ${TEST_USER} && \
       usermod -a -G wheel ${TEST_USER} && \
@@ -31,16 +31,20 @@ RUN wget https://ci.cloud.cnaf.infn.it/view/repos/job/repo_test_ca/lastSuccessfu
     chown -R test:test /home/test/.globus
 
 RUN yum -y install voms-clients-java gfal2-util gfal2-all gfal2-python davix jq && \
+    curl -sL https://rpm.nodesource.com/setup_14.x | bash - && \
+    yum install -y nodejs && \
+    npm install -g jwt-cli && \
     yum clean all && \
-    yum -y install https://github.com/indigo-dc/oidc-agent/releases/download/v3.3.5/oidc-agent-3.3.5-1.el7.x86_64.rpm && \
-    yum install -y python-pip python-enum && \
-    pip install --upgrade pip && \
-    pip install --upgrade robotframework-httplibrary && \
-    pip install --upgrade oic && \
-    pip install --upgrade requests && \
-    pip install --upgrade pyyaml && \
-    pip install --upgrade shyaml && \
-    pip install --upgrade oidc && \
+    wget https://repo.data.kit.edu/data-kit-edu-centos7.repo -O /etc/yum.repos.d/data-kit-edu-centos7.repo && \
+    yum install -y oidc-agent && \
+    pip3 install --upgrade pip && \
+    pip3 install --upgrade robotframework-httplibrary && \
+    pip3 install --upgrade oic && \
+    pip3 install --upgrade requests && \
+    pip3 install --upgrade pyyaml && \
+    pip3 install --upgrade shyaml && \
+    # bug in newer pyjwt version reported in https://github.com/Azure/azure-sdk-for-python/issues/16035
+    pip3 install pyjwt==1.7.0 && \
     rm -rf /var/cache/yum
 
 ENV TINI_VERSION v0.18.0

--- a/run-testsuite.sh
+++ b/run-testsuite.sh
@@ -39,5 +39,7 @@ fi
 
 export REQUESTS_CA_BUNDLE=${REQUESTS_CA_BUNDLE:-/etc/grid-security/certificates}
 
+alias python='python3'
+
 echo "JWT compliance test suite run against: $1"
 robot ${ARGS} --variable se_alias:$1 --name $1 -G $1 test 


### PR DESCRIPTION
Last successful docker build was more than one year ago.
Then it was failing with
```
#9 111.3   Downloading https://files.pythonhosted.org/packages/da/f6/c83229dcc3635cdeb51874184241a9508ada15d8baa337a41093fab58011/pip-21.3.1.tar.gz (1.7MB)
#9 111.9     Complete output from command python setup.py egg_info:
#9 111.9     Traceback (most recent call last):
#9 111.9       File "<string>", line 1, in <module>
#9 111.9       File "/tmp/pip-build-EQRZKX/pip/setup.py", line 7
#9 111.9         def read(rel_path: str) -> str:
#9 111.9                          ^
#9 111.9     SyntaxError: invalid syntax
#9 111.9     
#9 111.9     ----------------------------------------
#9 112.0 Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-EQRZKX/pip/
#9 112.1 You are using pip version 8.1.2, however version 21.3.1 is available.
#9 112.1 You should consider upgrading via the 'pip install --upgrade pip' command.
```

Switching to python3 solved the issue.
The docker image now is the same as for [escape-auth-tests](https://github.com/indigo-iam/escape-auth-tests).

Since the CI is triggered at any push on the master branch, I've tested the code locally:

* built docker image with tag `andreaceccanti/wlcg-jwt-compliance-tests`
* run test suite (same tag for the image is used in the docker-compose)

and it works fine.