### PR TITLE
Add support for running an individual test

### DIFF
--- a/run-testsuite.sh
+++ b/run-testsuite.sh
@@ -16,8 +16,14 @@
 #
 set -e
 
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 <seAlias>"
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: $0 <seAlias> [<test>]"
+  echo
+  echo "If specified, <test> indicates a single test from the suite that is to"
+  echo "be run.  If <test> is omitted then all tests are run."
+  echo
+  echo "\"Token with random audience is rejected\" (including the quotes) is"
+  echo "an example <test> value."
   exit 1
 fi
 
@@ -37,7 +43,12 @@ if [ -n "${ROBOT_ARGS}" ]; then
   ARGS="${ARGS} ${ROBOT_ARGS}"
 fi
 
+if [ $# -eq 2 ]; then
+  ARGS="${ARGS} -t \"$2\""
+  PREAMBLE="Test \"$2\" of "
+fi
+
 export REQUESTS_CA_BUNDLE=${REQUESTS_CA_BUNDLE:-/etc/grid-security/certificates}
 
-echo "JWT compliance test suite run against: $1"
-robot ${ARGS} --variable se_alias:$1 --name $1 -G $1 test 
+echo "${PREAMBLE}JWT compliance test suite run against: $1"
+eval robot ${ARGS} --variable se_alias:$1 --name $1 -G $1 test


### PR DESCRIPTION
Motivation:

Sometimes, typically when debugging a specific problem, it is useful to
run just a single test from the test-suite.  This allows for more
extensive debugging to be enabled.

Modification:

Add an optional second command-line argument to 'run-testsuite.sh' that
limits the testing to a specific test.

When only a single command-line argument is provided then the tests are
run as before.

Result:

It is now easy to run a single test from the suite.