### PR TITLE
Update amnensiac target alias in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can then run the testsuite against one of the registered endpoint
 
 ```
 cd test-suite
-./run-testsuite.sh cnaf-amnesiac
+./run-testsuite.sh se-cnaf-amnesiac-storm
 ```
 
 To add an endpoint, edit the `./test/variables.yaml` file.


### PR DESCRIPTION
Motivation:

Commit a50ee600 updated the predefined targets to include the underlying
software.  Unfortunately, this patch forgot to update the documentation.

Modification:

Update README.md file to include the updated se name given as an
example.

Result:

The README.md file now contains more accurate information.