### PR TITLE
Fix typo in the README document about read access vs read-only access

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ be configured as follows:
   - AuthZ will be based on the `storage.*` scopes in the token, e.g. a token
     with the `storage.modify:/` issued by the WLCG token issuer will grant
     write access on the whole storage area.
-- Read-only access (i.e., the ability to list directory contents and
+- Read access (i.e., the ability to list directory contents and
   read files) to all members of the WLCG VO, i.e.:
   - all clients presenting a valid VOMS proxy for the WLCG VO
   - all clients presenting a valid JWT token issued by the WLCG token issuer


### PR DESCRIPTION
Motivation:

Currently, the documentation contains an oxymoron.  It says that the
storage system should be configured so that it grants:

> Read-only access [...] to all members of the WLCG VO

Not the use of the word "only" in read-only.

This means that "all members of the WLCG VO" should not be authorised to
write into the storage.

This is then immediately contradicted where the documentation describes
which users should be granted write access to different parts of the
namespace.

Modification:

Change "read-only access" to "read access".

Result:

The documentation is no longer self-contradictory.