### PR TITLE
Add test suite summary results in email body

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -61,14 +61,11 @@ pipeline {
         script {
           TEST_RESULT = sh(
             returnStdout: true,
-            script: 'ci/get-ts-summary-results.sh'
+            script: 'ci/get-ts-summary-results.sh reports/reports/latest/joint-report.html'
           )
           emailext to: "${env.MAIL_RECIPIENTS}",
           subject: "WLCG JWT compliance test report - #${env.BUILD_NUMBER} ${env.BUILD_TIMESTAMP}",
-          body: \
-"${TEST_RESULT}\n\n\
-Report at ${env.BUILD_URL}artifact/reports/reports/latest/joint-report.html\n\n\
-Git repository at https://github.com/indigo-iam/wlcg-jwt-compliance-tests"
+          body: "${TEST_RESULT}"
         }
       }
     }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -59,10 +59,15 @@ pipeline {
       }
       steps {
         script {
+          TEST_RESULT = sh(
+            returnStdout: true,
+            script: 'ci/get-ts-summary-results.sh'
+          )
           emailext to: "${env.MAIL_RECIPIENTS}",
           subject: "WLCG JWT compliance test report - #${env.BUILD_NUMBER} ${env.BUILD_TIMESTAMP}",
           body: \
-"Report at ${env.BUILD_URL}artifact/reports/reports/latest/joint-report.html\n\n\
+"${TEST_RESULT}\n\n\
+Report at ${env.BUILD_URL}artifact/reports/reports/latest/joint-report.html\n\n\
 Git repository at https://github.com/indigo-iam/wlcg-jwt-compliance-tests"
         }
       }

--- a/ci/get-ts-summary-results.sh
+++ b/ci/get-ts-summary-results.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
-set -ex
+set -e
 
-cat reports/reports/latest/joint-report.html | grep '^window.output\["stats"\]' | sed -e 's/window.output\["stats"\] = //' -e 's/;$//' | jq '.[0][0] | {pass,fail} | join(" ")' | tr -d '"' | awk '{printf "| All Tests %d | Pass %d | Fail %d |\n", $1+$2, $1, $2}'
+if [ $# -lt 1 ]; then
+  exit 1
+fi
+
+report_file="$1"
+
+json_out=$(cat "${report_file}" | grep '^window.output\["stats"\]' | sed -e 's/window.output\["stats"\] = //' -e 's/;$//')
+
+passed_tests=$(echo "${json_out}" | jq .[0][0].pass)
+failed_tests=$(echo "${json_out}" | jq .[0][0].fail)
+
+echo
+echo "Test summary results"
+echo
+echo "All Tests $(( ${passed_tests} + ${failed_tests} ))"
+echo "Pass ${passed_tests}"
+echo "Fail ${failed_tests}"
+echo
+echo "Detailed report at ${BUILD_URL}artifact/reports/reports/latest/joint-report.html"
+echo
+echo "Git repository at https://github.com/indigo-iam/wlcg-jwt-compliance-tests"
+echo

--- a/ci/get-ts-summary-results.sh
+++ b/ci/get-ts-summary-results.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -ex
 
-cat reports/latest/joint-report.html | grep '^window.output\["stats"\]' | sed -e 's/window.output\["stats"\] = //' -e 's/;$//' | jq '.[0][0] | {pass,fail} | join(" ")' | tr -d '"' | awk '{printf "| All Tests %d | Pass %d | Fail %d|\n", $1+$2, $1, $2}'
+cat reports/reports/latest/joint-report.html | grep '^window.output\["stats"\]' | sed -e 's/window.output\["stats"\] = //' -e 's/;$//' | jq '.[0][0] | {pass,fail} | join(" ")' | tr -d '"' | awk '{printf "| All Tests %d | Pass %d | Fail %d|\n", $1+$2, $1, $2}'

--- a/ci/get-ts-summary-results.sh
+++ b/ci/get-ts-summary-results.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -ex
 
-cat reports/reports/latest/joint-report.html | grep '^window.output\["stats"\]' | sed -e 's/window.output\["stats"\] = //' -e 's/;$//' | jq '.[0][0] | {pass,fail} | join(" ")' | tr -d '"' | awk '{printf "| All Tests %d | Pass %d | Fail %d|\n", $1+$2, $1, $2}'
+cat reports/reports/latest/joint-report.html | grep '^window.output\["stats"\]' | sed -e 's/window.output\["stats"\] = //' -e 's/;$//' | jq '.[0][0] | {pass,fail} | join(" ")' | tr -d '"' | awk '{printf "| All Tests %d | Pass %d | Fail %d |\n", $1+$2, $1, $2}'

--- a/ci/get-ts-summary-results.sh
+++ b/ci/get-ts-summary-results.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+
+cat reports/latest/joint-report.html | grep '^window.output\["stats"\]' | sed -e 's/window.output\["stats"\] = //' -e 's/;$//' | jq '.[0][0] | {pass,fail} | join(" ")' | tr -d '"' | awk '{printf "| All Tests %d | Pass %d | Fail %d|\n", $1+$2, $1, $2}'


### PR DESCRIPTION
Created separate script to define the email report content, which includes now a summary on the testsuite results.

Tested in [CI](https://ci.cloud.cnaf.infn.it/view/wlcg/job/wlcg-jwt-compliance-tests/job/issue-26/14/) (build n. 14, where the email is sent to my personal account).

The email layout looks like
![email_wlcg-ts](https://user-images.githubusercontent.com/13579100/150394983-ed938131-7a35-4110-8d95-bde6742c2a52.png)
e