### PR TITLE
Add more path authorization enforced tests

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
   triggers { cron('00 15 * * *') }
 
   parameters {
-    string(defaultValue: "--exclude strict", description: 'Robot arguments', name: 'ROBOT_ARGS')
+    string(defaultValue: "--exclude strict --exclude TBD", description: 'Robot arguments', name: 'ROBOT_ARGS')
   }
 
   environment {

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Basic requirements for running the testsuite are:
 - be member of the `/wlcg/test` optional group in the WLCG IAM.  
   In order to join IAM groups you have to login to IAM and click the "Add to group" button; membership requests will be granted by VO admins afterwards.
 
-[iam-doc-oidc]: https://indigo-iam.github.io/v/v1.7.2/docs/tasks/user/getting-a-token/#registering-a-client
+[iam-doc-oidc]: https://indigo-iam.github.io/v/current/docs/tasks/user/getting-a-token/#registering-a-client
 
 ### Run with docker
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -34,7 +34,7 @@ rebot --nostatusrc \
   --log ${reports_dir}/joint-log.html \
   --ReportTitle "JWT compliance tests ${now}" \
   --name "JWT compliance tests" \
-  --tagstatinclude 'se-*' \
+  --tagstatinclude 'se-*' --tagstatinclude '*critical' \
   ${reports}
 
 if [ -n "${SKIP_REPORT_UPLOAD}" ]; then

--- a/common/curl.robot
+++ b/common/curl.robot
@@ -77,3 +77,9 @@ Curl MKCOL Success
     ${all_opts}   Set variable   -X MKCOL ${opts} -H "Authorization: Bearer %{${bearer.env}}"
     ${rc}  ${out}  Curl Success  ${url}  ${all_opts}
     [Return]  ${rc}  ${out}
+
+Curl MKCOL Error   
+    [Arguments]   ${url}   ${opts}=${curl.opts.default}
+    ${all_opts}   Set variable   -X MKCOL ${opts} -H "Authorization: Bearer %{${bearer.env}}"
+    ${rc}  ${out}  Curl Error  ${url}  ${all_opts}
+    [Return]  ${rc}  ${out}

--- a/common/curl.robot
+++ b/common/curl.robot
@@ -18,6 +18,10 @@ Curl Success  [Arguments]  ${url}  ${opts}=${curl.opts.default}
     ${rc}  ${out}   Execute and Check Success  curl ${url} ${opts}
     [Return]  ${rc}  ${out}
 
+Curl Auth Success  [Arguments]  ${url}  ${opts}=${curl.opts.default}
+    ${rc}  ${out}   Execute and Check Success  curl ${opts} -H "Authorization: Bearer %{${bearer.env}}" ${url}
+    [Return]  ${rc}  ${out}
+
 Curl Error   [Arguments]  ${url}  ${opts}=${curl.opts.default}
     ${rc}  ${out}   Execute and Check Failure  curl ${opts} -H "Authorization: Bearer %{${bearer.env}}" ${url}
     [Return]  ${rc}  ${out}

--- a/test/audience.robot
+++ b/test/audience.robot
@@ -7,6 +7,8 @@ Resource    common/http.robot
 
 Variables   test/variables.yaml
 
+Force Tags   critical
+
 
 *** Test cases ***
 

--- a/test/basic_authz.robot
+++ b/test/basic_authz.robot
@@ -6,7 +6,7 @@ Resource    common/oidc-agent.robot
 
 Variables   test/variables.yaml
 
-Force Tags   basic-authz-checks
+Force Tags   basic-authz-checks   critical
 
 *** Test cases ***
 

--- a/test/basic_authz.robot
+++ b/test/basic_authz.robot
@@ -74,28 +74,6 @@ Write access denied with storage.read:/
     ${url}   SE URL   robot-test-${uuid}
     ${rc}   ${out}   Curl Put Error   /etc/services  ${url}
     Should Contain   ${out}   403
-
-Path authorization enforced on storage.read
-    ${token}   Get token   scope=-s storage.read:/wlcg-jwt-compliance
-    ${endpoint}   GET SE endpoint   ${se_alias}
-    ${uuid}   Generate UUID
-    ${url}   Set Variable   ${endpoint}/not-found-${uuid}
-    ${rc}   ${out}   Curl Error   ${url}
-    Should Contain   ${out}   403
-    ${url}   SE URL  not-found-${uuid}
-    ${rc}   ${out}   Curl Error   ${url}
-    Should Contain   ${out}   404
-
-Path authorization enforced on storage.modify
-    ${token}   Get token   scope=-s storage.modify:/wlcg-jwt-compliance
-    ${endpoint}   GET SE endpoint   ${se_alias}
-    ${uuid}   Generate UUID
-    ${url}   Set Variable   ${endpoint}/not-found-${uuid}
-    ${rc}   ${out}   Curl Put Error   /etc/services  ${url}
-    Should Contain   ${out}   403
-    ${url}   SE URL  not-found-${uuid}
-     ${rc}   ${out}   Curl Put Success   /etc/services  ${url}
-    Should Match Regexp   ${out}   20[01]
     
 storage.modify does not imply storage.read
     ${token}   Get token

--- a/test/path_enforced_authz.robot
+++ b/test/path_enforced_authz.robot
@@ -32,22 +32,90 @@ Path authorization enforced on storage.modify
      ${rc}   ${out}   Curl Put Success   /etc/services  ${url}
     Should Match Regexp   ${out}   20[01]
 
-storage.read:/foo does not allow to read the /foobar file
-    ${token}   Get token
-    ${uuid}   Generate UUID
-    ${url}   SE URL   ${uuid}/foobar
-    ${rc}   ${out}   Curl PUT Success   /etc/services   ${url}
-    Should Match Regexp   ${out}   20[01]
-    ${token}   Get token   scope=-s storage.read:/foo
-    ${rc}   ${out}   Curl Error   ${url}
-    Should Contain   ${out}   403
+storage.read:/foobar allows to read the /foobar file
+    [Setup]   Create foobar directory and file
+    ${token}   Get token   scope=-s storage.read:/wlcg-jwt-compliance/${SUITE_UUID}/foobar
+    ${rc}   ${out}   Curl Auth Success   ${URL}
+    Should Contain   ${out}   ${file.content}
+    [Teardown]   Delete foobar directory and file
 
-storage.create:/foo does not allow to create the /foobar folder
+storage.read:/foo does not allow to read the /foobar file
+    [Setup]   Create foobar directory and file
+    ${token}   Get token   scope=-s storage.read:/wlcg-jwt-compliance/${SUITE_UUID}/foo
+    ${rc}   ${out}   Curl Error   ${URL}
+    Should Contain   ${out}   403
+    [Teardown]   Delete foobar directory and file
+
+Create directory allowed with storage.create scope
     ${token}   Get token
     ${uuid}   Generate UUID
-    ${url}   SE URL   ${uuid}
+    ${basename}   Set Variable   create-dir-${uuid}
+    ${url}   SE URL   ${basename}
     ${rc}   ${out}   Curl MKCOL Success   ${url}
     Should Match Regexp   ${out}   20[01]
-    ${token}   Get token   scope=-s storage.create:/foo
+    ${token}   Get token   scope=-s storage.create:/wlcg-jwt-compliance/${SUITE_UUID}/${basename}
+    ${rc}   ${out}   Curl MKCOL Success   ${url}/foobar
+    Should Match Regexp   ${out}   20[01]
+
+Create directory not allowed with storage.create scope and partial path
+    ${token}   Get token
+    ${uuid}   Generate UUID
+    ${basename}   Set Variable   create-dir-${uuid}
+    ${url}   SE URL   ${basename}
+    ${rc}   ${out}   Curl MKCOL Success   ${url}
+    Should Match Regexp   ${out}   20[01]
+    ${partial.basename}   Get Substring   ${basename}   0   -1
+    ${token}   Get token   scope=-s storage.create:/wlcg-jwt-compliance/${SUITE_UUID}/${partial.basename}
     ${rc}   ${out}   Curl MKCOL Error   ${url}/foobar
     Should Contain   ${out}   403
+
+storage.read scope with path not compliant with RFC3986 is rejected
+    [Setup]   Create foobar directory and file
+    ${token}   Get token   scope=-s storage.read:/foobar
+    ${rc}   ${out}   Curl Error   ${URL}
+    Should Contain   ${out}   403
+    ${token}   Get token   scope=-s storage.read:/foo
+    ${rc}   ${out}   Curl Error   ${URL}
+    Should Contain   ${out}   403
+    [Teardown]   Delete foobar directory and file
+
+Trailing slash allows to read into a directory
+    [Tags]   TBD
+    [Setup]   Create foobar directory and file
+    ${token}   Get token   scope=-s storage.read:/wlcg-jwt-compliance/${SUITE_UUID}/foobar/
+    ${rc}   ${out}   Curl Auth Success   ${URL}
+    Should Contain   ${out}   ${file.content}
+    ${token}   Get token   scope=-s storage.read:/wlcg-jwt-compliance/${SUITE_UUID}/foo/
+    ${rc}   ${out}   Curl Error   ${URL}
+    Should Contain   ${out}   403
+    ${token}   Get token   scope=-s storage.read:/wlcg-jwt-compliance/${SUITE_UUID}/foobar
+    ${rc}   ${out}   Curl Error   ${URL}
+    Should Contain   ${out}   403
+    [Teardown]   Delete foobar directory and file
+
+
+
+*** Variables ***
+
+${file.content}   wlcg-suite-content-file
+${file.name}   file
+
+
+*** Keywords ***
+
+Create foobar directory and file
+    ${token}   Get token
+    ${url}   SE URL   foobar
+    ${rc}   ${out}   Curl MKCOL Success   ${url}
+    Should Match Regexp   ${out}   20[01]
+    ${tmp.file}   Set Variable   /tmp/${file.name}
+    Create File   ${tmp.file}   ${file.content}
+    Set Test Variable   ${URL}      ${url}/${file.name}
+    ${rc}   ${out}   Curl PUT Success   ${tmp.file}   ${URL}
+    Should Match Regexp   ${out}   20[01]
+
+Delete foobar directory and file
+    ${token}   Get token
+    ${url}   SE URL   foobar
+    Curl DELETE Success   ${url}/${file.name}
+    Curl DELETE Success   ${url}

--- a/test/path_enforced_authz.robot
+++ b/test/path_enforced_authz.robot
@@ -1,0 +1,43 @@
+*** Settings ***
+
+Resource    common/endpoint.robot
+Resource    common/curl.robot
+Resource    common/oidc-agent.robot
+
+Variables   test/variables.yaml
+
+Force Tags   path-enforced-authz-checks
+
+*** Test cases ***
+
+Path authorization enforced on storage.read
+    ${token}   Get token   scope=-s storage.read:/wlcg-jwt-compliance
+    ${endpoint}   GET SE endpoint   ${se_alias}
+    ${uuid}   Generate UUID
+    ${url}   Set Variable   ${endpoint}/not-found-${uuid}
+    ${rc}   ${out}   Curl Error   ${url}
+    Should Contain   ${out}   403
+    ${url}   SE URL  not-found-${uuid}
+    ${rc}   ${out}   Curl Error   ${url}
+    Should Contain   ${out}   404
+
+Path authorization enforced on storage.modify
+    ${token}   Get token   scope=-s storage.modify:/wlcg-jwt-compliance
+    ${endpoint}   GET SE endpoint   ${se_alias}
+    ${uuid}   Generate UUID
+    ${url}   Set Variable   ${endpoint}/not-found-${uuid}
+    ${rc}   ${out}   Curl Put Error   /etc/services  ${url}
+    Should Contain   ${out}   403
+    ${url}   SE URL  not-found-${uuid}
+     ${rc}   ${out}   Curl Put Success   /etc/services  ${url}
+    Should Match Regexp   ${out}   20[01]
+
+storage.read:/foo does not allow to read the /foobar file
+    ${token}   Get token
+    ${uuid}   Generate UUID
+    ${url}   SE URL   ${uuid}/foobar
+    ${rc}   ${out}   Curl PUT Success   /etc/services   ${url}
+    Should Match Regexp   ${out}   20[01]
+    ${token}   Get token   scope=-s storage.read:/foo
+    ${rc}   ${out}   Curl Error   ${url}
+    Should Contain   ${out}   403

--- a/test/path_enforced_authz.robot
+++ b/test/path_enforced_authz.robot
@@ -41,3 +41,13 @@ storage.read:/foo does not allow to read the /foobar file
     ${token}   Get token   scope=-s storage.read:/foo
     ${rc}   ${out}   Curl Error   ${url}
     Should Contain   ${out}   403
+
+storage.create:/foo does not allow to create the /foobar folder
+    ${token}   Get token
+    ${uuid}   Generate UUID
+    ${url}   SE URL   ${uuid}
+    ${rc}   ${out}   Curl MKCOL Success   ${url}
+    Should Match Regexp   ${out}   20[01]
+    ${token}   Get token   scope=-s storage.create:/foo
+    ${rc}   ${out}   Curl MKCOL Error   ${url}/foobar
+    Should Contain   ${out}   403

--- a/test/path_enforced_authz.robot
+++ b/test/path_enforced_authz.robot
@@ -11,6 +11,7 @@ Force Tags   path-enforced-authz-checks
 *** Test cases ***
 
 Path authorization enforced on storage.read
+    [Tags]   critical
     ${token}   Get token   scope=-s storage.read:/wlcg-jwt-compliance
     ${endpoint}   GET SE endpoint   ${se_alias}
     ${uuid}   Generate UUID
@@ -22,6 +23,7 @@ Path authorization enforced on storage.read
     Should Contain   ${out}   404
 
 Path authorization enforced on storage.modify
+    [Tags]   critical
     ${token}   Get token   scope=-s storage.modify:/wlcg-jwt-compliance
     ${endpoint}   GET SE endpoint   ${se_alias}
     ${uuid}   Generate UUID
@@ -33,6 +35,7 @@ Path authorization enforced on storage.modify
     Should Match Regexp   ${out}   20[01]
 
 storage.read:/foobar allows to read into the /foobar directory
+    [Tags]   critical
     [Setup]   Create foobar directory and file
     ${token}   Get token   scope=-s storage.read:/wlcg-jwt-compliance/${SUITE_UUID}/foobar
     ${rc}   ${out}   Curl Auth Success   ${URL}
@@ -40,6 +43,7 @@ storage.read:/foobar allows to read into the /foobar directory
     [Teardown]   Delete foobar directory and file
 
 storage.read:/foo does not allow to read into the /foobar directory
+    [Tags]   not-critical
     [Setup]   Create foobar directory and file
     ${token}   Get token   scope=-s storage.read:/wlcg-jwt-compliance/${SUITE_UUID}/foo
     ${rc}   ${out}   Curl Error   ${URL}
@@ -47,6 +51,7 @@ storage.read:/foo does not allow to read into the /foobar directory
     [Teardown]   Delete foobar directory and file
 
 Create directory allowed with storage.create scope
+    [Tags]   critical
     ${token}   Get token
     ${uuid}   Generate UUID
     ${basename}   Set Variable   create-dir-${uuid}
@@ -58,6 +63,7 @@ Create directory allowed with storage.create scope
     Should Match Regexp   ${out}   20[01]
 
 Create directory not allowed with storage.create scope and partial path
+    [Tags]   not-critical
     ${token}   Get token
     ${uuid}   Generate UUID
     ${basename}   Set Variable   create-dir-${uuid}
@@ -70,6 +76,7 @@ Create directory not allowed with storage.create scope and partial path
     Should Contain   ${out}   403
 
 storage.read scope with path not compliant with RFC3986 is rejected
+    [Tags]   critical
     [Setup]   Create foobar directory and file
     ${token}   Get token   scope=-s storage.read:/foobar
     ${rc}   ${out}   Curl Error   ${URL}
@@ -80,7 +87,7 @@ storage.read scope with path not compliant with RFC3986 is rejected
     [Teardown]   Delete foobar directory and file
 
 Trailing slash allows to read into a directory
-    [Tags]   TBD
+    [Tags]   TBD   not-critical
     [Setup]   Create foobar directory and file
     ${token}   Get token   scope=-s storage.read:/wlcg-jwt-compliance/${SUITE_UUID}/foobar/
     ${rc}   ${out}   Curl Auth Success   ${URL}

--- a/test/path_enforced_authz.robot
+++ b/test/path_enforced_authz.robot
@@ -32,14 +32,14 @@ Path authorization enforced on storage.modify
      ${rc}   ${out}   Curl Put Success   /etc/services  ${url}
     Should Match Regexp   ${out}   20[01]
 
-storage.read:/foobar allows to read the /foobar file
+storage.read:/foobar allows to read into the /foobar directory
     [Setup]   Create foobar directory and file
     ${token}   Get token   scope=-s storage.read:/wlcg-jwt-compliance/${SUITE_UUID}/foobar
     ${rc}   ${out}   Curl Auth Success   ${URL}
     Should Contain   ${out}   ${file.content}
     [Teardown]   Delete foobar directory and file
 
-storage.read:/foo does not allow to read the /foobar file
+storage.read:/foo does not allow to read into the /foobar directory
     [Setup]   Create foobar directory and file
     ${token}   Get token   scope=-s storage.read:/wlcg-jwt-compliance/${SUITE_UUID}/foo
     ${rc}   ${out}   Curl Error   ${URL}


### PR DESCRIPTION
This PR was requested during a DOMA BDT meeting, following the discussion in issue https://github.com/WLCG-AuthZ-WG/common-jwt-profile/issues/21.

Here more path authorization enforced tests are added, in particular

1. *storage.read:/foobar allows to read into the /foobar directory*
2. *storage.read:/foo does not allow to read into the /foobar directory*
3. *Create directory allowed with storage.create scope*
4. *Create directory not allowed with storage.create scope and partial path*
5. *storage.read scope with path not compliant with RFC3986 is rejected*.  
  In this case we check that a GET HTTP request returns a forbidden status on the existing resource `/wlcg-jwt-compliance/<uuid>/foobar` with a bearer token that has a `storage.read:/foobar` scope
6. *Trailing slash allows to read into a directory*.
  This test is excluded from the CI (*i.e.* is not present in the summary email report) since I guess is still under discussion. What we're testing is that a `storage.read:/foobar/` scope allows to read into an existing `/foobar` directory, while `storage.read:/foo/` and `storage.read:/foobar` forbids to read into that directory (obviously this test will never success if test 1 above passes as well).

The tests number 2 and 4 are the ones that breaks the fully compliance of dCache and StoRM WebDAV sites, thus they have been tagged as `not-critical` (while the remaining ones are `critical`). In this way one can filter the test report by tag to check directly the result.

The summary tests report of this PR is available [here](https://ci.cloud.cnaf.infn.it/view/wlcg/job/wlcg-jwt-compliance-tests/job/PR-40/lastSuccessfulBuild/artifact/reports/reports/latest/joint-report.html).