### PR TITLE
Update RAL test gateway host

### DIFF
--- a/test/variables.yaml
+++ b/test/variables.yaml
@@ -95,7 +95,7 @@ endpoints:
   se-ral-test-xrootd:
     desc: Test gateway for Echo
     type: XRootD
-    endpoint: https://ceph-dev-gw2.gridpp.rl.ac.uk:1094
+    endpoint: https://ceph-dev-gw4.gridpp.rl.ac.uk:1094
     paths:
       wlcg: /dteam:wlcg
   se-ubonn-xrootd:


### PR DESCRIPTION
Update the RAL test hostname to a new dedicated testbed host.